### PR TITLE
build: switch to new-style github workflows (1.19.3 dev work)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
-name: Java CI
+name: Java CI - Build on Push
 
 on:
   push:
-    branches:
-      # main and dev versions for each mc ver here
-      - "1.19/main"
-      - "1.19/dev"
+    branches: [ main, "1.*" ]
+  workflow_dispatch:
+    inputs:
+      skip_maven_publish:
+        description: 'Skip Maven publishing'
+        required: true
+        default: 'false'
 
 jobs:
   build:
@@ -13,30 +16,26 @@ jobs:
     if: |
       !contains(github.event.head_commit.message, '[ci skip]')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 30 # Gets the last 30 commits so the changelog might work
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Build and Publish with Gradle
+      - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --no-daemon
+      - name: Publish to Maven
+        uses: gradle/gradle-build-action@v2
+        if: github.event.inputs.skip_maven_publish != 'true'
         env:
           FTB_MAVEN_TOKEN: ${{ secrets.FTB_MAVEN_TOKEN }}
           SAPS_TOKEN: ${{ secrets.SAPS_TOKEN }}
+          SNAPSHOT: true
         with:
-          arguments: build publish --stacktrace --no-daemon
-      - name: Release to CurseForge
-        uses: gradle/gradle-build-action@v2
-        if: |
-          contains(github.ref, 'main') && !contains(github.event.head_commit.message, '[norelease]') && github.event.inputs.norelease != 'true'
-        env:
-          GIT_COMMIT: ${{ github.event.after }}
-          GIT_PREVIOUS_COMMIT: ${{ github.event.before }}
-          CURSEFORGE_KEY: ${{ secrets.CURSEFORGE_KEY }}
-        with:
-          arguments: build curseforge --stacktrace --no-daemon
+          arguments: publish --no-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Java CI - Build Release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export release tag as environment variable
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 30 # Gets the last 30 commits so the changelog might work
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --no-daemon
+      - name: Publish to Maven
+        uses: gradle/gradle-build-action@v2
+        env:
+          FTB_MAVEN_TOKEN: ${{ secrets.FTB_MAVEN_TOKEN}}
+          SAPS_TOKEN: ${{ secrets.SAPS_TOKEN }}
+        with:
+          arguments: publish --no-daemon
+      - name: Release to CurseForge
+        uses: gradle/gradle-build-action@v2
+        env:
+          GIT_COMMIT: ${{ github.event.after }}
+          GIT_PREVIOUS_COMMIT: ${{ github.event.before }}
+          CURSEFORGE_KEY: ${{ secrets.CURSEFORGE_KEY }}
+          CHANGELOG: ${{ github.event.release.body }}
+        with:
+          arguments: curseforge --no-daemon


### PR DESCRIPTION
Switching over to the new-style build system (curseforge publishing driven by github releases) for FTB Library as of 1.19.3.  Code is still subject to refactoring before any releases are done, but a lot has been done already, mostly around ditching public mutable fields :P

First PR to commit to the `main` (1.19.3) branch, which is now a protected branch.