### PR TITLE
ci: build on branches "1.**" not "1.*"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Java CI - Build on Push
 
 on:
   push:
-    branches: [ main, dev, "1.*" ]
+    branches: [ main, dev, "1.**" ]
   workflow_dispatch:
     inputs:
       skip_maven_publish:


### PR DESCRIPTION
Small CI fix to ensure 1.20.1/dev branch is built