### PR TITLE
chore: separate dep version from required dep version for neoforge/fabric

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -42,7 +42,7 @@ processResources {
 	filesMatching("fabric.mod.json") {
 		expand "version": project.version,
 				"archversion": project.architectury_version,
-				"fabricapiversion": project.fabric_api_version,
+				"fabricapiversionrange": project.fabric_api_version_range,
 				"mcversion": project.minecraft_version
 	}
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
 		"ftblibrary-fabric.mixins.json"
 	],
 	"depends": {
-		"fabric": ">=${fabricapiversion}",
+		"fabric": "${fabricapiversionrange}",
 		"minecraft": "~${mcversion}",
 		"architectury": ">=${archversion}"
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,11 @@ minecraft_version=1.21
 # Deps
 forge_version=49.0.31
 neoforge_version=21.0.146
+neoforge_version_range=[21.0.143,)
 neoforge_loader_version=4
 fabric_loader_version=0.15.11
-fabric_api_version=0.100.1+1.21
+fabric_api_version=0.100.8+1.21
+fabric_api_version_range=>=0.100.1+1.21
 
 architectury_version=13.0.2
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -50,7 +50,7 @@ processResources {
 	filesMatching("META-INF/neoforge.mods.toml") {
 		expand "version": project.version,
 				"archversion": project.architectury_version,
-				"neoforgeversion": project.neoforge_version,
+				"neoforgeversionrange": project.neoforge_version_range,
 				"neoforgeloaderversion": project.neoforge_loader_version,
 				"mcversion": project.minecraft_version
 	}

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -18,7 +18,7 @@ FTB Library adds nothing.
 [[dependencies.ftblibrary]]
 modId = "neoforge"
 type = "required"
-versionRange = "[${neoforgeversion},)"
+versionRange = "${neoforgeversionrange}"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Updated the fabric api version as well (but didn't change the min required version)