### PR TITLE
[1.21] Fix StringMapValue config gettings keys from wrong compound

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftblibrary/snbt/config/StringMapValue.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/snbt/config/StringMapValue.java
@@ -30,7 +30,7 @@ public class StringMapValue extends BaseValue<Map<String, String>> {
 
         SNBTCompoundTag compound = tag.getCompound(key);
         for (String key : compound.getAllKeys()) {
-            map.put(key, tag.getString(key));
+            map.put(key, compound.getString(key));
         }
 
         set(map);

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/snbt/config/StringMapValue.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/snbt/config/StringMapValue.java
@@ -28,7 +28,8 @@ public class StringMapValue extends BaseValue<Map<String, String>> {
     public void read(SNBTCompoundTag tag) {
         Map<String, String> map = new HashMap<>();
 
-        for (String key : tag.getAllKeys()) {
+        SNBTCompoundTag compound = tag.getCompound(key);
+        for (String key : compound.getAllKeys()) {
             map.put(key, tag.getString(key));
         }
 


### PR DESCRIPTION
- Simple fix to actually load existing config data

Fixes https://github.com/FTBTeam/FTB-Modpack-Issues/issues/5809