### PR TITLE
Use ModifyReturnValue for ResourceLocation error suppression

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftblibrary/core/mixin/common/ResourceLocationMixin.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/core/mixin/common/ResourceLocationMixin.java
@@ -1,25 +1,20 @@
 package dev.ftb.mods.ftblibrary.core.mixin.common;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import dev.ftb.mods.ftblibrary.util.StringUtils;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ResourceLocation.class)
 public class ResourceLocationMixin {
-    @Inject(method = {"validPathChar", "validNamespaceChar"}, at = @At("HEAD"), cancellable = true)
-    private static void validCharFTBJ(char c, CallbackInfoReturnable<Boolean> ci) {
-        if (StringUtils.ignoreResourceLocationErrors) {
-            ci.setReturnValue(true);
-        }
+    @ModifyReturnValue(method = {"validPathChar", "validNamespaceChar"}, at = @At("RETURN"))
+    private static boolean validCharFTBJ(boolean original) {
+        return original || StringUtils.ignoreResourceLocationErrors;
     }
 
-    @Inject(method = {"isValidPath", "isValidNamespace"}, at = @At("HEAD"), cancellable = true)
-    private static void validStringFTBJ(String s, CallbackInfoReturnable<Boolean> ci) {
-        if (StringUtils.ignoreResourceLocationErrors) {
-            ci.setReturnValue(true);
-        }
+    @ModifyReturnValue(method = {"isValidPath", "isValidNamespace"}, at = @At("RETURN"))
+    private static boolean validStringFTBJ(boolean original) {
+        return original || StringUtils.ignoreResourceLocationErrors;
     }
 }


### PR DESCRIPTION
This avoids the `CallbackInfoReturnable` allocation caused by using `@Inject`.