### PR TITLE
Fix NeoForge compatibility for 1.21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 # Mod
 mod_id=ftblibrary
 readable_name=FTB Library
-mod_version=2106.0.1
+mod_version=2106.0.1-SNAPSHOT
 mod_author=FTB Team
 # Maven
 archives_base_name=ftb-library


### PR DESCRIPTION
Update to MC Version 1.21.7 and NeoForge 21.7.2-beta,21.7.18-beta

based on this pull request from Architectury API: https://github.com/architectury/architectury-api/blob/2b8b696d241f12affe898e11df3e5767cfc78df6/gradle.properties
