### PR TITLE
Fix execClientCommand incorrectly stripping all forward slashes from commands

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftblibrary/util/client/ClientUtils.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/util/client/ClientUtils.java
@@ -37,7 +37,7 @@ public class ClientUtils {
                 if (printChat) {
                     Minecraft.getInstance().gui.getChat().addRecentChat(command);
                 }
-                Minecraft.getInstance().player.connection.sendCommand(command.replace("/", ""));
+                Minecraft.getInstance().player.connection.sendCommand(command.replaceFirst("/", ""));
             }
         }
     }


### PR DESCRIPTION
## Problem

The `execClientCommand` method in `ClientUtils` currently uses `command.replace("/", "")`, which removes **all** forward slashes from the command string.
https://github.com/FTBTeam/FTB-Library/blob/d5afa8baf0e526914b5b6d73ac904951e50f597b/common/src/main/java/dev/ftb/mods/ftblibrary/util/client/ClientUtils.java#L40
This breaks commands that contain file paths. For example, when using the following command in an **FTB Quests image click**:
`command:/guidemec ae2:guide open advanced_ae:aae_intro/quantum_computer.md`
<img width="2534" height="938" alt="image" src="https://github.com/user-attachments/assets/637bd6fd-2c89-4dd5-ab48-6283215fcbd9" />

The actual command send becomes:
`/guidemec ae2:guide open advanced_ae:aae_introquantum_computer.md`

The forward slash in the path is incorrectly stripped, causing the guide page to fail to open.
<img width="1054" height="182" alt="image" src="https://github.com/user-attachments/assets/b5ed022f-8831-4a70-9107-2523ae75f574" />

## Root Cause

The original intent was to remove the leading `/` prefix from Minecraft commands (e.g., `/say` → `say`), but `replace("/", "")` mistakenly performs a global replacement, affecting all slashes in the command.

## Solution

Replace `command.replace("/", "")` with `command.replaceFirst("^/", "")` to only remove the leading slash (if present), preserving all other slashes in the command.

## Before vs After

| Input Command | Before | After |
|--------------|--------|-------|
| `/say hello` | `say hello` ✅ | `say hello` ✅ |
| `say hello` | `say hello` ✅ | `say hello` ✅ |
| `guidemec ae2:guide open a/b.md` | `guidemec ae2:guide open ab.md` ❌ | `guidemec ae2:guide open a/b.md` ✅ |
| `/guidemec ae2:guide open a/b.md` | `guidemec ae2:guide open ab.md` ❌ | `guidemec ae2:guide open a/b.md` ✅ |

## Impact

- Fixes commands with paths (containing `/`) not working with the `command:` prefix
- Does not affect existing command execution behavior (leading `/` is still properly removed)