### PR TITLE
Rework widget scrolling to support x+y scrolling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
     id "dev.architectury.loom" version "1.10-SNAPSHOT" apply false
-    id "me.modmuss50.mod-publish-plugin" version "2.0.0-beta.2"
+    id "me.modmuss50.mod-publish-plugin" version "2.1.0"
 }
 
 apply from: 'https://raw.githubusercontent.com/FTBTeam/mods-meta/main/gradle/changelog.gradle'

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/EditStringConfigOverlay.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/EditStringConfigOverlay.java
@@ -165,12 +165,12 @@ public class EditStringConfigOverlay<T> extends ModalPanel {
         }
 
         @Override
-        public boolean mouseScrolled(double scroll) {
-            return config.scrollValue(currentValue, scroll > 0).map(v -> {
+        public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
+            return config.scrollValue(currentValue, scrollVertical > 0).map(v -> {
                 textBox.setText(config.getStringFromValue(v));
                 textBox.setSelectionPos(textBox.getCursorPos());
                 return true;
-            }).orElse(super.mouseScrolled(scroll));
+            }).orElse(super.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical));
         }
     }
 }

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/EditStringConfigOverlay.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/EditStringConfigOverlay.java
@@ -166,7 +166,8 @@ public class EditStringConfigOverlay<T> extends ModalPanel {
 
         @Override
         public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
-            return config.scrollValue(currentValue, yDelta > 0).map(v -> {
+            var directionlessDelta = xDelta != 0 ? xDelta : yDelta;
+            return config.scrollValue(currentValue, directionlessDelta > 0).map(v -> {
                 textBox.setText(config.getStringFromValue(v));
                 textBox.setSelectionPos(textBox.getCursorPos());
                 return true;

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/EditStringConfigOverlay.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/EditStringConfigOverlay.java
@@ -165,12 +165,12 @@ public class EditStringConfigOverlay<T> extends ModalPanel {
         }
 
         @Override
-        public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
-            return config.scrollValue(currentValue, scrollVertical > 0).map(v -> {
+        public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
+            return config.scrollValue(currentValue, yDelta > 0).map(v -> {
                 textBox.setText(config.getStringFromValue(v));
                 textBox.setSelectionPos(textBox.getCursorPos());
                 return true;
-            }).orElse(super.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical));
+            }).orElse(super.mouseScrolled(mouseX, mouseY, xDelta, yDelta));
         }
     }
 }

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/resource/ResourceSelectorScreen.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/resource/ResourceSelectorScreen.java
@@ -1,7 +1,5 @@
 package dev.ftb.mods.ftblibrary.config.ui.resource;
 
-import com.google.common.base.Stopwatch;
-import com.mojang.datafixers.util.Pair;
 import dev.ftb.mods.ftblibrary.FTBLibrary;
 import dev.ftb.mods.ftblibrary.config.ConfigCallback;
 import dev.ftb.mods.ftblibrary.config.ResourceConfigValue;
@@ -21,6 +19,8 @@ import dev.ftb.mods.ftblibrary.ui.misc.AbstractThreePanelScreen;
 import dev.ftb.mods.ftblibrary.ui.misc.SimpleToast;
 import dev.ftb.mods.ftblibrary.util.SearchTerms;
 import dev.ftb.mods.ftblibrary.util.TooltipList;
+import com.google.common.base.Stopwatch;
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
@@ -347,13 +347,13 @@ public abstract class ResourceSelectorScreen<T> extends AbstractThreePanelScreen
         }
 
         @Override
-        public boolean mouseScrolled(double scroll) {
+        public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
             if (!isMouseOver) return false;
             if (isShiftKeyDown()) {
-                int adj = scroll > 0 ? getCount() : -getCount() / 2;
+                int adj = scrollVertical > 0 ? getCount() : -getCount() / 2;
                 adjust(adj);
             } else {
-                adjust((int) Math.signum(scroll));
+                adjust((int) Math.signum(scrollVertical));
             }
             return true;
         }

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/resource/ResourceSelectorScreen.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/resource/ResourceSelectorScreen.java
@@ -349,11 +349,13 @@ public abstract class ResourceSelectorScreen<T> extends AbstractThreePanelScreen
         @Override
         public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
             if (!isMouseOver) return false;
+
+            var directionlessDelta = xDelta != 0 ? xDelta : yDelta;
             if (isShiftKeyDown()) {
-                int adj = yDelta > 0 ? getCount() : -getCount() / 2;
+                int adj = directionlessDelta > 0 ? getCount() : -getCount() / 2;
                 adjust(adj);
             } else {
-                adjust((int) Math.signum(yDelta));
+                adjust((int) Math.signum(directionlessDelta));
             }
             return true;
         }

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/resource/ResourceSelectorScreen.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/config/ui/resource/ResourceSelectorScreen.java
@@ -347,13 +347,13 @@ public abstract class ResourceSelectorScreen<T> extends AbstractThreePanelScreen
         }
 
         @Override
-        public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
+        public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
             if (!isMouseOver) return false;
             if (isShiftKeyDown()) {
-                int adj = scrollVertical > 0 ? getCount() : -getCount() / 2;
+                int adj = yDelta > 0 ? getCount() : -getCount() / 2;
                 adjust(adj);
             } else {
-                adjust((int) Math.signum(scrollVertical));
+                adjust((int) Math.signum(yDelta));
             }
             return true;
         }

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/BaseScreen.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/BaseScreen.java
@@ -1,7 +1,5 @@
 package dev.ftb.mods.ftblibrary.ui;
 
-import com.mojang.blaze3d.platform.InputConstants;
-import com.mojang.blaze3d.platform.Window;
 import dev.ftb.mods.ftblibrary.icon.Color4I;
 import dev.ftb.mods.ftblibrary.ui.input.Key;
 import dev.ftb.mods.ftblibrary.ui.input.KeyModifiers;
@@ -10,6 +8,8 @@ import dev.ftb.mods.ftblibrary.ui.misc.LoadingScreen;
 import dev.ftb.mods.ftblibrary.util.BooleanConsumer;
 import dev.ftb.mods.ftblibrary.util.TooltipList;
 import dev.ftb.mods.ftblibrary.util.client.ClientUtils;
+import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.ChatScreen;
@@ -468,11 +468,11 @@ public abstract class BaseScreen extends Panel {
     }
 
     @Override
-    public boolean mouseScrolled(double scroll) {
-        if (focusedWidget != null && focusedWidget.mouseScrolled(scroll)) {
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
+        if (focusedWidget != null && focusedWidget.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical)) {
             return true;
         }
-        return modalPanels.isEmpty() ? super.mouseScrolled(scroll) : modalPanels.peekFirst().mouseScrolled(scroll);
+        return modalPanels.isEmpty() ? super.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical) : modalPanels.peekFirst().mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical);
     }
 
     @Override

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/BaseScreen.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/BaseScreen.java
@@ -468,11 +468,11 @@ public abstract class BaseScreen extends Panel {
     }
 
     @Override
-    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
-        if (focusedWidget != null && focusedWidget.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical)) {
+    public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
+        if (focusedWidget != null && focusedWidget.mouseScrolled(mouseX, mouseY, xDelta, yDelta)) {
             return true;
         }
-        return modalPanels.isEmpty() ? super.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical) : modalPanels.peekFirst().mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical);
+        return modalPanels.isEmpty() ? super.mouseScrolled(mouseX, mouseY, xDelta, yDelta) : modalPanels.peekFirst().mouseScrolled(mouseX, mouseY, xDelta, yDelta);
     }
 
     @Override

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/DropDownMenu.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/DropDownMenu.java
@@ -32,11 +32,6 @@ public class DropDownMenu extends ModalPanel implements PopupMenu {
     }
 
     @Override
-    public boolean scrollPanel(double scroll) {
-        return super.scrollPanel(scroll);
-    }
-
-    @Override
     public void addWidgets() {
         add(textBox);
         add(mainPanel);

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/IntTextBox.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/IntTextBox.java
@@ -44,8 +44,10 @@ public class IntTextBox extends TextBox {
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
+        var directionlessDelta = xDelta != 0 ? xDelta : yDelta;
+
         if (allowInput()) {
-            setAmount(getIntValue() + (int) yDelta);
+            setAmount(getIntValue() + (int) directionlessDelta);
             return true;
         }
         return false;

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/IntTextBox.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/IntTextBox.java
@@ -43,9 +43,9 @@ public class IntTextBox extends TextBox {
     }
 
     @Override
-    public boolean mouseScrolled(double scroll) {
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
         if (allowInput()) {
-            setAmount(getIntValue() + (int) scroll);
+            setAmount(getIntValue() + (int) scrollVertical);
             return true;
         }
         return false;

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/IntTextBox.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/IntTextBox.java
@@ -43,9 +43,9 @@ public class IntTextBox extends TextBox {
     }
 
     @Override
-    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
+    public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
         if (allowInput()) {
-            setAmount(getIntValue() + (int) scrollVertical);
+            setAmount(getIntValue() + (int) yDelta);
             return true;
         }
         return false;

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Panel.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Panel.java
@@ -379,12 +379,10 @@ public abstract class Panel extends Widget {
         // If the user is pressing shift, we'll always attempt to scroll horizontally, otherwise we'll just blindly apply both directions
         if (isShiftKeyDown()) {
             var scrollAmount = -getScrollStep() * directionlessDelta;
-            movePanelScroll(scrollAmount, 0);
+            return movePanelScroll(scrollAmount, 0);
         } else {
-            movePanelScroll(-getScrollStep() * xDelta, -getScrollStep() * yDelta);
+            return movePanelScroll(-getScrollStep() * xDelta, -getScrollStep() * yDelta);
         }
-
-        return true;
     }
 
     public boolean movePanelScroll(double dx, double dy) {

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Panel.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Panel.java
@@ -331,19 +331,19 @@ public abstract class Panel extends Widget {
     }
 
     @Override
-    public boolean mouseScrolled(double scroll) {
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
         setOffset(true);
 
         for (var i = widgets.size() - 1; i >= 0; i--) {
             var widget = widgets.get(i);
 
-            if (widget.isEnabled() && widget.mouseScrolled(scroll)) {
+            if (widget.isEnabled() && widget.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical)) {
                 setOffset(false);
                 return true;
             }
         }
 
-        var scrollPanel = scrollPanel(scroll);
+        var scrollPanel = scrollPanel(scrollHorizontal, scrollVertical);
         setOffset(false);
         return scrollPanel;
     }
@@ -365,16 +365,16 @@ public abstract class Panel extends Widget {
         return false;
     }
 
-    public boolean scrollPanel(double scroll) {
+    public boolean scrollPanel(double scrollHorizontal, double scrollVertical) {
         if (attachedScrollbar != null || !isMouseOver()) {
             return false;
         }
 
-        if (isDefaultScrollVertical() != isShiftKeyDown()) {
-            return movePanelScroll(0, -getScrollStep() * scroll);
-        } else {
-            return movePanelScroll(-getScrollStep() * scroll, 0);
-        }
+        var isInverted = isDefaultScrollVertical() != isShiftKeyDown();
+        return movePanelScroll(
+                isInverted ? scrollHorizontal : -getScrollStep() * scrollVertical,
+                isInverted ? -getScrollStep() * scrollVertical : scrollHorizontal
+        );
     }
 
     public boolean movePanelScroll(double dx, double dy) {

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Panel.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Panel.java
@@ -331,19 +331,19 @@ public abstract class Panel extends Widget {
     }
 
     @Override
-    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
+    public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
         setOffset(true);
 
         for (var i = widgets.size() - 1; i >= 0; i--) {
             var widget = widgets.get(i);
 
-            if (widget.isEnabled() && widget.mouseScrolled(mouseX, mouseY, scrollHorizontal, scrollVertical)) {
+            if (widget.isEnabled() && widget.mouseScrolled(mouseX, mouseY, xDelta, yDelta)) {
                 setOffset(false);
                 return true;
             }
         }
 
-        var scrollPanel = scrollPanel(scrollHorizontal, scrollVertical);
+        var scrollPanel = scrollPanel(xDelta, yDelta);
         setOffset(false);
         return scrollPanel;
     }
@@ -365,16 +365,26 @@ public abstract class Panel extends Widget {
         return false;
     }
 
-    public boolean scrollPanel(double scrollHorizontal, double scrollVertical) {
+    public boolean scrollPanel(double xDelta, double yDelta) {
         if (attachedScrollbar != null || !isMouseOver()) {
             return false;
         }
 
-        var isInverted = isDefaultScrollVertical() != isShiftKeyDown();
-        return movePanelScroll(
-                isInverted ? scrollHorizontal : -getScrollStep() * scrollVertical,
-                isInverted ? -getScrollStep() * scrollVertical : scrollHorizontal
-        );
+        // No scroll direction was given?
+        var directionlessDelta = yDelta != 0 ? yDelta : xDelta;
+        if (directionlessDelta == 0) {
+            return false;
+        }
+
+        // If the user is pressing shift, we'll always attempt to scroll horizontally, otherwise we'll just blindly apply both directions
+        if (isShiftKeyDown()) {
+            var scrollAmount = -getScrollStep() * directionlessDelta;
+            movePanelScroll(scrollAmount, 0);
+        } else {
+            movePanelScroll(-getScrollStep() * xDelta, -getScrollStep() * yDelta);
+        }
+
+        return true;
     }
 
     public boolean movePanelScroll(double dx, double dy) {
@@ -402,10 +412,6 @@ public abstract class Panel extends Widget {
         }
 
         return getScrollX() != sx || getScrollY() != sy;
-    }
-
-    public boolean isDefaultScrollVertical() {
-        return true;
     }
 
     public double getScrollStep() {

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/ScreenWrapper.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/ScreenWrapper.java
@@ -1,10 +1,10 @@
 package dev.ftb.mods.ftblibrary.ui;
 
-import dev.architectury.platform.Platform;
 import dev.ftb.mods.ftblibrary.ui.input.Key;
 import dev.ftb.mods.ftblibrary.ui.input.KeyModifiers;
 import dev.ftb.mods.ftblibrary.ui.input.MouseButton;
 import dev.ftb.mods.ftblibrary.util.TooltipList;
+import dev.architectury.platform.Platform;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.item.ItemStack;
@@ -53,7 +53,9 @@ public class ScreenWrapper extends Screen implements IScreenWrapper {
 
     @Override
     public boolean mouseScrolled(double x, double y, double dirX, double dirY) {
-        return wrappedGui.mouseScrolled(dirY) || super.mouseScrolled(x, y, dirX, dirY);
+        return wrappedGui.mouseScrolled(x, y, dirX, dirY) ||
+                wrappedGui.mouseScrolled(dirY) || // TODO: Remove this when all guis are updated to the new mouseScrolled method
+                super.mouseScrolled(x, y, dirX, dirY);
     }
 
     @Override

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/ScrollBar.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/ScrollBar.java
@@ -71,9 +71,11 @@ public class ScrollBar extends Widget {
     }
 
     @Override
-    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
-        if (scrollVertical != 0 && canMouseScrollPlane() && canMouseScroll()) {
-            setValue(getValue() - getScrollStep() * scrollVertical);
+    public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
+        // We don't care which direction the user scrolled, just apply it.
+        var scrollDelta = yDelta == 0  ? xDelta : yDelta;
+        if (scrollDelta != 0 && canMouseScrollPlane() && canMouseScroll()) {
+            setValue(getValue() - getScrollStep() * scrollDelta);
             return true;
         }
 

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/ScrollBar.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/ScrollBar.java
@@ -71,9 +71,9 @@ public class ScrollBar extends Widget {
     }
 
     @Override
-    public boolean mouseScrolled(double scroll) {
-        if (scroll != 0 && canMouseScrollPlane() && canMouseScroll()) {
-            setValue(getValue() - getScrollStep() * scroll);
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
+        if (scrollVertical != 0 && canMouseScrollPlane() && canMouseScroll()) {
+            setValue(getValue() - getScrollStep() * scrollVertical);
             return true;
         }
 

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Widget.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Widget.java
@@ -196,12 +196,12 @@ public class Widget implements IScreenWrapper, Comparable<Widget> {
      * @deprecated use {@link #mouseScrolled(double, double, double, double)} instead
      */
     @Deprecated
-    public boolean mouseScrolled(double scroll) {
+    public boolean mouseScrolled(double yDelta) {
         return false;
     }
 
-    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
-        return false;
+    public boolean mouseScrolled(double mouseX, double mouseY, double xDelta, double yDelta) {
+        return this.mouseScrolled(yDelta);
     }
 
     public boolean mouseDragged(int button, double dragX, double dragY) {

--- a/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Widget.java
+++ b/common/src/main/java/dev/ftb/mods/ftblibrary/ui/Widget.java
@@ -1,11 +1,11 @@
 package dev.ftb.mods.ftblibrary.ui;
 
-import com.mojang.blaze3d.platform.Window;
 import dev.ftb.mods.ftblibrary.ui.input.Key;
 import dev.ftb.mods.ftblibrary.ui.input.KeyModifiers;
 import dev.ftb.mods.ftblibrary.ui.input.MouseButton;
 import dev.ftb.mods.ftblibrary.util.TooltipList;
 import dev.ftb.mods.ftblibrary.util.client.PositionedIngredient;
+import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
@@ -192,7 +192,15 @@ public class Widget implements IScreenWrapper, Comparable<Widget> {
     public void mouseReleased(MouseButton button) {
     }
 
+    /**
+     * @deprecated use {@link #mouseScrolled(double, double, double, double)} instead
+     */
+    @Deprecated
     public boolean mouseScrolled(double scroll) {
+        return false;
+    }
+
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollHorizontal, double scrollVertical) {
         return false;
     }
 


### PR DESCRIPTION
This __shouldn't__ break anything with existing mods but I could have missed something. This is a required change to allow FTB Quests and other related panels that use scrolling as a pan method to work with trackpads, ball scrolling, etc